### PR TITLE
Review

### DIFF
--- a/mz-user-reviews-dbt-demo/README.md
+++ b/mz-user-reviews-dbt-demo/README.md
@@ -2,9 +2,9 @@
 
 This is a self-contained demo using [Materialize](https://materialize.com/).
 
-This demo would show you how to use dbt together with Materialize.
+This demo shows you how to use [dbt](https://docs.getdbt.com/docs/introduction) together with Materialize.
 
-For this demo, we are going to monitor the reviews left by users on our demo website, and we will use dbt models to get a list of important users that left bad reviews so we could use this data and potentially reach out to them and improve our website.
+For this demo, we are going to monitor the reviews left by users on a demo website, and use dbt to model our business logic, like getting a list of important users that left bad reviews. We will then explore how to use this data to potentially reach out to the flagged users and improve our website experience.
 
 ![How to use dbt with Materialize](https://user-images.githubusercontent.com/21223421/146195691-e24401ab-20b5-43a2-b921-3dd6627d7f1f.png)
 
@@ -16,20 +16,20 @@ You can follow the steps here on how to install Docker:
 
 > [Installing Docker](https://materialize.com/docs/third-party/docker/)
 
-Also, you would need to make sure that you have the `dbt` command installed:
+Also, you would need to make sure that you have `dbt` (v0.18.1+) installed:
 
 > [Installing dbt](https://materialize.com/docs/third-party/dbt/)
 
 ## Overview
 
-As shown in the diagram above we will have the following components:
+As shown in the diagram above, we will have the following components:
 
 - A mock service to continually generate reviews and users.
-- The reviews and the users would be stored in a MySQL database.
+- The reviews and the users will be stored in a MySQL database.
 - As the database writes occur, Debezium streams the changes out of MySQL to a Redpanda topic.
-- We would then ingest this Redpanda topic into Materialize directly.
-- After that, we will use dbt to transform the data and create a model that can be used to get a list of VIP users that left bad reviews.
-- You could, later on, use the information and visualize it in a BI tool like Metabase.
+- We then ingest this Redpanda topic into Materialize directly.
+- After that, we use dbt to define transformations on the data and create a model that lists any VIP users that left bad reviews.
+- You could, later on, visualize the data in a BI tool like Metabase.
 
 > As a side note here, you would be perfectly fine using Kafka instead of Redpanda. I just like the simplicity that Redpanda brings to the table, as you can run a single Redpanda instance instead of all of the Kafka components.
 
@@ -41,13 +41,13 @@ First, start by cloning the repository:
 git clone https://github.com/bobbyiliev/materialize-tutorials.git
 ```
 
-After that you can access the directory:
+After that, you can access the directory:
 
 ```
 cd materialize-tutorials/mz-user-reviews-dbt-demo
 ```
 
-Let's start by first running the Redpanda container:
+Let's start by running the Redpanda container:
 
 ```
 docker-compose up -d redpanda
@@ -65,19 +65,19 @@ Finally, start all of the services:
 docker-compose up -d
 ```
 
-In order to Launch the Materialize CLI, you can run the following command:
+In order to launch the Materialize CLI, you can run the following command:
 
 ```
 docker-compose run mzcli
 ```
 
-> This is just a shortcut to a docker container with `postgres-client` pre-installed, if you already have `psql` you could run `psql -U materialize -h localhost -p 6875 materialize` instead.
+> This is just a shortcut to a Docker container with a compatible CLI pre-installed; if you already have `psql` installed, you could instead connect to the running Materialize instance using that: `psql -U materialize -h localhost -p 6875 materialize`.
 
 As soon as the demo is running, the mock service will start generating reviews and users.
 
 ### Create a Materialize Kafka/Redpanda Source
 
-Now that you're in the Materialize CLI, let's define the `users`, `roles` and `reviews` tables in the `mysql.db` database as Kafka/Redpanda sources:
+Now that you're in the Materialize CLI, let's define three Kafka/Redpanda sources: `users`, `roles` and `reviews`, that will pull in the change data captured in Redpanda from the original tables in the `mysql.db`.
 
 ```sql
 CREATE SOURCE users
@@ -96,13 +96,13 @@ FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://redpanda:8081'
 ENVELOPE DEBEZIUM;
 ```
 
-If you were to check the available columns from the `reviews` source by running the following statement:
+You can check the columns of the `reviews` source by running the following statement:
 
 ```sql
 SHOW COLUMNS FROM reviews;
 ```
 
-You would be able to see that, as Materialize is pulling the message schema data from the Redpanda registry, it knows the column types to use for each attribute:
+You'll see that, as Materialize is pulling the message schema from the [Redpanda registry](https://vectorized.io/blog/schema_registry/), it knows the column types to use for each attribute:
 
 ```sql
      name      | nullable |   type
@@ -117,7 +117,7 @@ You would be able to see that, as Materialize is pulling the message schema data
 
 ### Prepare dbt configuration
 
-First, we will need to install the `dbt-materialize` plugin:
+First, we will need to install the [`dbt-materialize`](https://pypi.org/project/dbt-materialize/) plugin:
 
 ```
 python3 -m venv dbt-venv
@@ -143,7 +143,7 @@ user_reviews:
   target: dev
 ```
 
-After that to make sure that the connection to the Materialize container is working run:
+After that, to make sure that the connection to the Materialize container is working, run:
 
 ```
 dbt debug
@@ -157,7 +157,7 @@ dbt run
 
 This command generates executable SQL from our model files (found in the `models` directory of this project) and executes that SQL against the target database, creating our materialized views.
 
-> Note: If you installed dbt-materialize in a virtual environment, make sure it's activated. If you don't have it installed, please revisit the setup above.
+> Note: If you installed `dbt-materialize` in a virtual environment, make sure it's activated. If you don't have it installed, please revisit the setup above.
 
 Finally, you can run your dbt tests:
 
@@ -186,10 +186,10 @@ Output:
 You can also verify the data is being pulled from Redpanda by running the following query a few times:
 
 ```sql
-SELECT COUNTS(*) FROM vipusersbadreviews;
+SELECT COUNT(*) FROM vipusersbadreviews;
 ```
 
-You will be able to see that the result changes each time you run the query meaning that the data is being pulled from Redpanda continuously without having to run `dbt run` again.
+You will be able to see that the result changes each time you run the query, meaning that the data is being incrementally updated without you having to run `dbt run` again.
 
 ### Generate the dbt docs
 
@@ -205,21 +205,31 @@ After that you can serve the docs by running the following command:
 dbt docs serve
 ```
 
-Then visit the docs at http://localhost:8080/dbt/docs/. There you will have a list of all the views that were created and you can click on any of them to see the SQL that was generated. You would also see some nice Lineage Graphs that show the relationships between the views:
+Then visit the docs at http://localhost:8080/dbt/docs/. There, you will have a list of all the views that were created and you can click on any of them to see the SQL that was generated. You would also see some nice Lineage Graphs that show the relationships between the views:
 
 ![dbt Lineage Graph](https://user-images.githubusercontent.com/21223421/146348749-8fe67e3c-8587-42c0-aed4-8551ee2f1ff3.png)
 
 ## Metabase
 
-In order to access the [Metabase](https://materialize.com/docs/third-party/metabase/) instance visit `http://localhost:3030` if you are running the demo locally or `http://your_server_ip:3030` if you are running the demo on a server. Then follow the steps to complete the Metabase setup.
+In order to access the [Metabase](https://materialize.com/docs/third-party/metabase/) instance, visit `http://localhost:3030` if you are running the demo locally or `http://your_server_ip:3030` if you are running the demo on a server. Then follow the steps to complete the Metabase setup.
 
-Make sure to select Materialize as the source of the data.
+Materialize integrates natively with Metabase using the official PostgreSQL connector. To connect to your Materialize database, specify the following connection properties:
 
-Once ready you will be able to visualize your data just as you would with a standard PostgreSQL database.
+Field             | Value
+----------------- | ----------------
+Database          | PostgreSQL
+Name              | user_reviews
+Host              | **materialized**
+Port              | **6875**
+Database name     | **materialize**
+Database username | **materialize**
+Database password | Leave empty
+
+Once ready, you will be able to visualize your data just as you would with a standard PostgreSQL database.
 
 ## Stopping the Demo
 
-To stop all of the services run the following command:
+To stop all of the services, run the following command:
 
 ```
 docker-compose down
@@ -227,17 +237,16 @@ docker-compose down
 
 ## Conclusion
 
-As you can see, this is a very simple example of how to use Materialize together with dbt. You can use Materialize to ingest data from a variety of sources and then stream it to a variety of destinations.
+As you can see, this is a barebones example of how to use Materialize together with dbt. You can use Materialize to ingest data from a variety of sources and then stream it to a variety of destinations.
 
 To learn more about dbt and Materialize, check out the documentation here:
 
 - [dbt + Materialize demo: Running dbt’s jaffle_shop with Materialize](https://materialize.com/dbt-materialize-jaffle-shop-demo/)
 - [dbt + Materialize: streaming Wikipedia data demo](https://github.com/MaterializeInc/materialize/blob/main/play/wikirecent-dbt/README.md)
-- [Materialize and dbt docs](https://materialize.com/docs/guides/dbt/)
+- [Materialize and dbt getting started guide](https://materialize.com/docs/guides/dbt/)
 
 ## Helpful resources:
 
-* [`CREATE SOURCE: PostgreSQL`](https://materialize.com/docs/sql/create-source/postgres/)
 * [`CREATE SOURCE`](https://materialize.com/docs/sql/create-source/)
-* [`CREATE VIEWS`](https://materialize.com/docs/sql/create-views)
+* [`CREATE MATERIALIZED VIEW`](https://materialize.com/docs/sql/create-materialized-view/)
 * [`SELECT`](https://materialize.com/docs/sql/select)

--- a/mz-user-reviews-dbt-demo/docker-compose.yml
+++ b/mz-user-reviews-dbt-demo/docker-compose.yml
@@ -1,10 +1,10 @@
 version: '3.9'
 services:
   materialized:
-    image: materialize/materialized:v0.9.13
+    image: materialize/materialized:v0.15.0
     container_name: materialized
     init: true
-    command: -w1 --disable-telemetry --experimental
+    command: -w1 --disable-telemetry
     ports:
       - 6875:6875
     depends_on:
@@ -65,7 +65,7 @@ services:
     ports:
       - 8083:8083
   metabase:
-    image: materialize/metabase:v0.0.5
+    image: metabase/metabase
     container_name: metabase
     depends_on:
        - materialized


### PR DESCRIPTION
Sorry it took me so long to get to this, @bobbyiliev. 😢  There are a few things that caught my eye:

- You could feed the data directly into Redpanda to make the setup less complex.

- The diagram makes it look like dbt is handling raw data and feeding the transformed data back to Materialize, when it's just the place where you define and manage the transformations as models. All the transformations happen within Materialize (which I assume you know, but is just not clear from the diagram!).

- Is there a reason you don't define the sources also as dbt models? Though there is an issue with referencing sources (see [#8744](https://github.com/MaterializeInc/database-issues/issues/2676)), you can (and should) include all the objects in the dbt project. This mostly means that you have to use `ref()` instead of `source()` to reference the sources, and that they won't be highlighted properly in the lineage graph (_i.e._ in green):

<img width="736" alt="Screenshot 2022-01-10 at 11 51 30" src="https://user-images.githubusercontent.com/23521087/148754144-238d5aab-a411-4b65-ac47-e4d803ebc12e.png">

- There's a bunch of empty folders that you can get rid of. In practice, for this demo you only need `models` and the `dbt_project.yml` file.
- In the project file, you have:
  ```sql
  models:
    user_reviews:
      marts:
          core:
              materialized: materializedview
              intermediate:
                  materialized: view
      staging:
          materialized: view
          tags: ["staging", "hourly"]
  ```
    Looks like something that shouldn't be there, since you override the configuration in the models themselves?

- From v0.12.0, Materialize integrates natively with Metabase, so you don't need to use the custom image anymore. The integration uses the PostgreSQL connector.